### PR TITLE
Draft: Generic parse tree to type

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -1204,6 +1204,11 @@ test "parseTreeAlloc/free" {
         \\  1
         \\  2
         \\  3
+        \\c:
+        \\  foo: "foo'd"
+        \\  bar: "bar'd"
+        \\  baz: "baz'd"
+        \\
         ,
     );
 
@@ -1211,6 +1216,11 @@ test "parseTreeAlloc/free" {
         struct {
             a: []const u8,
             bs: [][]const u8,
+            c: struct{
+                foo: []const u8,
+                bar: []const u8,
+                baz: []const u8,
+            },
         },
         testing.allocator,
         test_tree.root,
@@ -1219,8 +1229,12 @@ test "parseTreeAlloc/free" {
 
     try testing.expectEqualSlices(u8, "testing, testing...", foo.a);
 
-    try testing.expectEqual(@as(usize, 3), foo.bs.len);
+    try testing.expect(foo.bs.len == 3);
     try testing.expectEqualSlices(u8, "1", foo.bs[0]);
     try testing.expectEqualSlices(u8, "2", foo.bs[1]);
     try testing.expectEqualSlices(u8, "3", foo.bs[2]);
+
+    try testing.expectEqualSlices(u8, "foo'd", foo.c.foo);
+    try testing.expectEqualSlices(u8, "bar'd", foo.c.bar);
+    try testing.expectEqualSlices(u8, "baz'd", foo.c.baz);
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -908,7 +908,10 @@ test "node appending and searching" {
     _ = try tree.appendValue(root, "3.14");
     _ = try tree.appendValue(root, "true");
 
-    try testing.expectEqual(@as(usize, 6), root.getChildCount());
+    const nested = try tree.appendValue(root, "nested");
+    _ = try tree.appendValue(nested, "descendent");
+
+    try testing.expectEqual(@as(usize, 7), root.getChildCount());
     try testing.expect(root.findNthChild(0, "") != null);
 
     try testing.expect(root.findNthChild(0, "Hello") != null);
@@ -926,6 +929,18 @@ test "node appending and searching" {
 
     try testing.expect(root.findNthChild(0, "true") != null);
     try testing.expect(root.findNthChild(1, "true") == null);
+
+    try testing.expect(root.findChild("Hello") != null);
+    try testing.expect(root.findChild("foo") != null);
+    try testing.expect(root.findChild("42") != null);
+    try testing.expect(root.findChild("3.14") != null);
+    try testing.expect(root.findChild("true") != null);
+    try testing.expect(root.findChild("nested") != null);
+
+    try testing.expect(root.findChild("descendent") == null);
+
+    try testing.expect(root.findDescendant("nested") != null);
+    try testing.expect(root.findDescendant("descendent") != null);
 }
 
 test "appending node" {


### PR DESCRIPTION
Adds some fns for parsing trees as arbitrary Zig types.

**Supports**
- nested structs
- slices of arbitrary length
- enums identified by name

**todo**
- parse float and int leaf nodes; only string leaf nodes are currently supported
- tuples